### PR TITLE
fix: 限制 BGM 链接匹配范围

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- 限制 BGM 链接只匹配条目开头的 BGM ID，避免标题或备注中的方括号数字被误链接。
+
 ### Added
 
 - 添加给条目追加或更新当前完成时间的代码操作。

--- a/extension.js
+++ b/extension.js
@@ -73,6 +73,30 @@ function applyCurrentTimeToEntryLine(line, timestamp = formatBangumiPlanDateTime
   return line.slice(0, insertAt) + timestamp + line.slice(insertAt);
 }
 
+function findBgmIdLinks(text) {
+  const links = [];
+  let lineStart = 0;
+
+  for (const line of text.split(/\r?\n/)) {
+    const parsed = parseEntryLine(line);
+    if (parsed?.bgmId) {
+      const token = `[${parsed.bgmId}]`;
+      const tokenStart = line.indexOf(token);
+      if (tokenStart !== -1) {
+        links.push({
+          id: parsed.bgmId,
+          start: lineStart + tokenStart,
+          end: lineStart + tokenStart + token.length,
+        });
+      }
+    }
+
+    lineStart += line.length + 1;
+  }
+
+  return links;
+}
+
 /**
  * @param {vscode.ExtensionContext} context
  */
@@ -100,23 +124,18 @@ function activate(context) {
 
 class BgmLinkProvider {
   provideDocumentLinks(document) {
-    const links = [];
-    const regex = /\[(\d+)\]/g;
-    let match;
-    while ((match = regex.exec(document.getText())) !== null) {
-      const id = match[1];
+    return findBgmIdLinks(document.getText()).map(({ id, start, end }) => {
       const range = new vscode.Range(
-        document.positionAt(match.index),
-        document.positionAt(match.index + match[0].length)
+        document.positionAt(start),
+        document.positionAt(end)
       );
       const link = new vscode.DocumentLink(
         range,
         vscode.Uri.parse(`https://bgm.tv/subject/${id}`)
       );
       link.tooltip = `跳转到 BGM ID: ${id}`;
-      links.push(link);
-    }
-    return links;
+      return link;
+    });
   }
 }
 
@@ -305,4 +324,5 @@ module.exports = {
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
+  findBgmIdLinks,
 };

--- a/test/entryRegex.test.js
+++ b/test/entryRegex.test.js
@@ -4,6 +4,7 @@ const {
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
+  findBgmIdLinks,
 } = require("../extension.js");
 
 // 使用 Mocha 的 describe/it 结构执行测试用例
@@ -703,5 +704,27 @@ describe("当前时间代码操作辅助函数", () => {
     const result = applyCurrentTimeToEntryLine("动画:");
 
     assert.strictEqual(result, null);
+  });
+});
+
+describe("BGM ID 链接辅助函数", () => {
+  it("只链接条目开头的 BGM ID", () => {
+    const input = [
+      "正在看:",
+      "    动画:",
+      "        [123456]作品名 [789]标题一部分 (说明[111])",
+      "        无ID作品 [222]标题一部分",
+      "备注 [333]",
+    ].join("\n");
+
+    const result = findBgmIdLinks(input);
+
+    assert.deepStrictEqual(result, [
+      {
+        id: "123456",
+        start: input.indexOf("[123456]"),
+        end: input.indexOf("[123456]") + "[123456]".length,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## 变更

- 将 BGM 链接扫描从全文正则匹配改为逐行解析合法条目。
- 只为条目开头的 `[BGM_ID]` 生成链接，避免标题、说明或非条目行中的 `[数字]` 被误链。
- 新增链接辅助函数测试覆盖误匹配场景。

## 影响

减少 `.bp` 文件中标题或备注包含方括号数字时的错误跳转链接。

## 验证

- 使用 VS Code 测试入口运行扩展测试：36 passing。
