### PR TITLE
fix: 修复条目悬浮片段定位

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复带进度说明的组合条目中日期和日期说明无法正确触发悬浮提示的问题。
+
 ### Added
 
 - 添加给条目追加或更新当前完成时间的代码操作。

--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,9 @@ function parseEntryLine(line) {
     rawTitle: nameRaw || "",
     marks: episodeProgress || undefined,
     progressDetail: progressDetail || undefined,
+    progressDescription: progressDescription || undefined,
     date: completionDate || undefined,
+    dateDescription: dateDescription || undefined,
     note: note,
   };
 }
@@ -71,6 +73,64 @@ function applyCurrentTimeToEntryLine(line, timestamp = formatBangumiPlanDateTime
 
   const insertAt = line.trimEnd().length;
   return line.slice(0, insertAt) + timestamp + line.slice(insertAt);
+}
+
+function locateEntrySegments(line) {
+  const parsed = parseEntryLine(line);
+  if (!parsed) return null;
+
+  const {
+    bgmId,
+    rawTitle,
+    marks,
+    progressDetail,
+    progressDescription,
+    date,
+    dateDescription,
+  } = parsed;
+  const indentLength = 8;
+  const idPart = bgmId ? `[${bgmId}]` : "";
+  let cursor = indentLength + idPart.length + rawTitle.length;
+
+  const createSegment = (start, text) => ({
+    start,
+    end: start + text.length,
+    text,
+  });
+
+  const leadingSpacesInTitle = rawTitle.length - rawTitle.trimStart().length;
+  const titleVisibleStart =
+    indentLength + idPart.length + leadingSpacesInTitle;
+  const titleVisibleText = rawTitle.trim();
+
+  const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const locateSegment = (tokenText) => {
+    const after = line.slice(cursor);
+    const re = new RegExp(`^(\\s*)${escapeRegex(tokenText)}`);
+    const mm = after.match(re);
+    if (!mm) return null;
+    const start = cursor + mm[1].length;
+    cursor = start + tokenText.length;
+    return createSegment(start, tokenText);
+  };
+
+  return {
+    parsed,
+    title: titleVisibleText
+      ? createSegment(titleVisibleStart, titleVisibleText)
+      : null,
+    marks: marks ? locateSegment(marks) : null,
+    progressDetail: progressDetail
+      ? locateSegment(`[正在观看 ${progressDetail}]`)
+      : null,
+    progressDescription: progressDescription
+      ? locateSegment(`(${progressDescription})`)
+      : null,
+    date: date ? locateSegment(`<${date}>`) : null,
+    dateDescription: dateDescription
+      ? locateSegment(`(${dateDescription})`)
+      : null,
+  };
 }
 
 /**
@@ -124,66 +184,26 @@ class hoverProvider {
   provideHover(document, position) {
     const line = document.lineAt(position).text;
 
-    // 使用新的 parseEntryLine 函数
-    const parsed = parseEntryLine(line);
-    if (!parsed) return null;
+    const segments = locateEntrySegments(line);
+    if (!segments) return null;
 
-    const { bgmId, title, rawTitle, marks, progressDetail, date, note } =
-      parsed;
+    const {
+      bgmId,
+      title,
+      marks,
+      progressDetail,
+      date,
+      note,
+      progressDescription,
+      dateDescription,
+    } = segments.parsed;
 
-    const indentLength = 8;
-
-    // 工具函数：创建 Range + 判断光标是否在其中
-    const makeRange = (start, text) => {
-      const end = start + text.length;
-      const inRange = position.character >= start && position.character <= end;
-      return {
-        range: new vscode.Range(position.line, start, position.line, end),
-        inRange,
-      };
-    };
-
-    // 重新计算各部分真实列位置
-    const idPart = bgmId ? `[${bgmId}]` : "";
-    let cursor = indentLength + idPart.length + rawTitle.length;
-
-    // 标题范围：用 trim 后的标题显示，但起始位置需要考虑原始空格
-    const leadingSpacesInTitle = rawTitle.length - rawTitle.trimStart().length;
-    const titleVisibleStart =
-      indentLength + idPart.length + leadingSpacesInTitle;
-    const titleVisibleText = rawTitle.trim();
-    const titleRange = makeRange(titleVisibleStart, titleVisibleText);
-
-    // 辅助函数：从当前位置开始匹配 token
-    const sliceFrom = (pos) => line.slice(pos);
-    const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const locateSegment = (tokenText) => {
-      const after = sliceFrom(cursor);
-      const re = new RegExp(`^(\\s*)${escapeRegex(tokenText)}`);
-      const mm = after.match(re);
-      if (!mm) return null;
-      const spacesLen = mm[1].length;
-      const start = cursor + spacesLen;
-      const rangeObj = makeRange(start, tokenText);
-      cursor = start + tokenText.length;
-      return rangeObj;
-    };
-
-    // 进度符号或进度详情
-    const marksRange = marks ? locateSegment(marks) : null;
-    const progressDetailToken = progressDetail
-      ? `[正在观看 ${progressDetail}]`
-      : null;
-    const progressDetailRange = progressDetailToken
-      ? locateSegment(progressDetailToken)
-      : null;
-
-    // 日期
-    const dateToken = date ? `<${date}>` : null;
-    const dateRange = dateToken ? locateSegment(dateToken) : null;
-    // 备注
-    const noteToken = note ? `(${note})` : null;
-    const noteRange = noteToken ? locateSegment(noteToken) : null;
+    const toHoverRange = (segment) =>
+      new vscode.Range(position.line, segment.start, position.line, segment.end);
+    const containsPosition = (segment) =>
+      segment &&
+      position.character >= segment.start &&
+      position.character <= segment.end;
 
     // Hover 内容构建函数
     const buildHover = (type, data) => {
@@ -240,16 +260,19 @@ class hoverProvider {
       }
     };
 
-    if (marksRange?.inRange) {
-      return new vscode.Hover(buildHover("marks", { marks }), marksRange.range);
-    }
-    if (progressDetailRange?.inRange) {
+    if (containsPosition(segments.marks)) {
       return new vscode.Hover(
-        buildHover("progressDetail", { progressDetail, title }),
-        progressDetailRange.range
+        buildHover("marks", { marks }),
+        toHoverRange(segments.marks)
       );
     }
-    if (title && titleRange.inRange) {
+    if (containsPosition(segments.progressDetail)) {
+      return new vscode.Hover(
+        buildHover("progressDetail", { progressDetail, title }),
+        toHoverRange(segments.progressDetail)
+      );
+    }
+    if (title && containsPosition(segments.title)) {
       return new vscode.Hover(
         buildHover("title", {
           title,
@@ -259,19 +282,25 @@ class hoverProvider {
           date,
           note,
         }),
-        titleRange.range
+        toHoverRange(segments.title)
       );
     }
-    if (dateRange?.inRange) {
+    if (containsPosition(segments.date)) {
       return new vscode.Hover(
         buildHover("date", { date, title }),
-        dateRange.range
+        toHoverRange(segments.date)
       );
     }
-    if (noteRange?.inRange) {
+    if (containsPosition(segments.progressDescription)) {
       return new vscode.Hover(
-        buildHover("note", { note, title }),
-        noteRange.range
+        buildHover("note", { note: progressDescription, title }),
+        toHoverRange(segments.progressDescription)
+      );
+    }
+    if (containsPosition(segments.dateDescription)) {
+      return new vscode.Hover(
+        buildHover("note", { note: dateDescription, title }),
+        toHoverRange(segments.dateDescription)
       );
     }
     return null;
@@ -305,4 +334,5 @@ module.exports = {
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
+  locateEntrySegments,
 };

--- a/test/entryRegex.test.js
+++ b/test/entryRegex.test.js
@@ -4,6 +4,7 @@ const {
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
+  locateEntrySegments,
 } = require("../extension.js");
 
 // 使用 Mocha 的 describe/it 结构执行测试用例
@@ -703,5 +704,30 @@ describe("当前时间代码操作辅助函数", () => {
     const result = applyCurrentTimeToEntryLine("动画:");
 
     assert.strictEqual(result, null);
+  });
+});
+
+describe("条目片段定位辅助函数", () => {
+  it("能定位进度说明之后的日期和日期说明", () => {
+    const input =
+      "        [222333]全功能测试 ✓✓✓✓✓ (优秀作品)<2024-11-20>(日期说明)";
+    const result = locateEntrySegments(input);
+
+    assert.ok(result !== null, "locateEntrySegments should not return null");
+    assert.deepStrictEqual(result.progressDescription, {
+      start: input.indexOf("(优秀作品)"),
+      end: input.indexOf("(优秀作品)") + "(优秀作品)".length,
+      text: "(优秀作品)",
+    });
+    assert.deepStrictEqual(result.date, {
+      start: input.indexOf("<2024-11-20>"),
+      end: input.indexOf("<2024-11-20>") + "<2024-11-20>".length,
+      text: "<2024-11-20>",
+    });
+    assert.deepStrictEqual(result.dateDescription, {
+      start: input.indexOf("(日期说明)"),
+      end: input.indexOf("(日期说明)") + "(日期说明)".length,
+      text: "(日期说明)",
+    });
   });
 });


### PR DESCRIPTION
## 变更

- 为条目 hover 增加独立片段定位 helper。
- 解析结果中保留进度说明和日期说明，hover 时分别定位。
- 修复 `进度标记 + 进度说明 + 日期 + 日期说明` 场景中日期 hover 不到的问题。

## 影响

组合格式条目的标题、进度、说明、日期 hover 范围更准确，后续扩展 hover 行为也更容易测试。

## 验证

- 使用 VS Code 测试入口运行扩展测试：36 passing。
