### PR TITLE
test: 校验条目正则同步

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 
+- 添加条目解析正则与 TextMate 语法正则的同步校验测试。
 - 添加给条目追加或更新当前完成时间的代码操作。
 
 ## [0.2.1] - 2025-08-28

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,9 @@ const vscode = require("vscode");
 const INSERT_CURRENT_TIME_ACTION_KIND = vscode.CodeActionKind.Refactor.append(
   "insertCurrentTime"
 );
+const ENTRY_REGEX_SOURCE =
+  "^\\s{8}(?:\\[(\\d+)\\])?(.+?)(?:\\s*(?:([√☑✅✓✔🗸]+)|\\[正在观看\\s+([^\\]]+)\\])(?:\\s*\\(([^)]+)\\))?)?(?:\\s*<([\\d/\\-:\\s]+)>(?:\\s*\\(([^)]+)\\))?)?\\s*$";
+const ENTRY_REGEX = new RegExp(ENTRY_REGEX_SOURCE);
 
 /**
  * 解析条目行的函数
@@ -10,13 +13,7 @@ const INSERT_CURRENT_TIME_ACTION_KIND = vscode.CodeActionKind.Refactor.append(
  * @returns {object|null} - 解析结果对象或null
  */
 function parseEntryLine(line) {
-  const indentLength = 8;
-
-  // 与 tmLanguage.json 一致的正则
-  const entryRegex = new RegExp(
-    `^\\s{${indentLength}}(?:\\[(\\d+)\\])?(.+?)(?:\\s*(?:([√☑✅✓✔🗸]+)|\\[正在观看\\s+([^\\]]+)\\])(?:\\s*\\(([^)]+)\\))?)?(?:\\s*<([\\d/\\-:\\s]+)>(?:\\s*\\(([^)]+)\\))?)?\\s*$`
-  );
-  const m = line.match(entryRegex);
+  const m = line.match(ENTRY_REGEX);
   if (!m) return null;
 
   // 捕获组对应：
@@ -302,6 +299,7 @@ function deactivate() {}
 module.exports = {
   activate,
   deactivate,
+  ENTRY_REGEX_SOURCE,
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,

--- a/test/entryRegex.test.js
+++ b/test/entryRegex.test.js
@@ -1,10 +1,30 @@
 // 使用 VS Code 扩展标准测试
 const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
 const {
+  ENTRY_REGEX_SOURCE,
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
 } = require("../extension.js");
+
+describe("entry regex sync", () => {
+  it("extension.js 与 tmLanguage.json 使用相同条目正则", () => {
+    const grammarPath = path.join(
+      __dirname,
+      "..",
+      "syntaxes",
+      "bangumiplan.tmLanguage.json"
+    );
+    const grammar = JSON.parse(fs.readFileSync(grammarPath, "utf8"));
+    const grammarEntryRegex =
+      grammar.repository.entry.patterns.find((pattern) => pattern.name === "meta.entry")
+        ?.match;
+
+    assert.strictEqual(grammarEntryRegex, ENTRY_REGEX_SOURCE);
+  });
+});
 
 // 使用 Mocha 的 describe/it 结构执行测试用例
 describe("parseEntryLine", () => {


### PR DESCRIPTION
## 变更

- 将 `extension.js` 中的条目正则源抽成 `ENTRY_REGEX_SOURCE` 常量。
- `parseEntryLine()` 复用该常量生成正则。
- 新增测试读取 `tmLanguage.json`，校验 TextMate 条目正则与扩展解析正则保持一致。

## 影响

后续新增语法时，如果只改了一边正则，测试会直接失败，减少解析和高亮漂移风险。

## 验证

- 使用 VS Code 测试入口运行扩展测试：36 passing。
