### PR TITLE
refactor: 拆分条目解析模块

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- 将条目解析与当前时间辅助逻辑拆分到独立 parser 模块，方便脱离 VS Code 宿主测试。
+
 ### Added
 
 - 添加给条目追加或更新当前完成时间的代码操作。

--- a/extension.js
+++ b/extension.js
@@ -1,77 +1,13 @@
 const vscode = require("vscode");
+const {
+  parseEntryLine,
+  formatBangumiPlanDateTime,
+  applyCurrentTimeToEntryLine,
+} = require("./parser");
 
 const INSERT_CURRENT_TIME_ACTION_KIND = vscode.CodeActionKind.Refactor.append(
   "insertCurrentTime"
 );
-
-/**
- * 解析条目行的函数
- * @param {string} line - 要解析的行
- * @returns {object|null} - 解析结果对象或null
- */
-function parseEntryLine(line) {
-  const indentLength = 8;
-
-  // 与 tmLanguage.json 一致的正则
-  const entryRegex = new RegExp(
-    `^\\s{${indentLength}}(?:\\[(\\d+)\\])?(.+?)(?:\\s*(?:([√☑✅✓✔🗸]+)|\\[正在观看\\s+([^\\]]+)\\])(?:\\s*\\(([^)]+)\\))?)?(?:\\s*<([\\d/\\-:\\s]+)>(?:\\s*\\(([^)]+)\\))?)?\\s*$`
-  );
-  const m = line.match(entryRegex);
-  if (!m) return null;
-
-  // 捕获组对应：
-  // 1: subject_id (bgmId)
-  // 2: 名称 (name)
-  // 3: 进度标记 (episode_progress)
-  // 4: 进度详情 (progress_detail)
-  // 5: 进度说明 (progress_description)
-  // 6: 完成时间 (completion_date)
-  // 7: 日期说明 (date_description)
-  const [
-    ,
-    subjectId,
-    nameRaw,
-    episodeProgress,
-    progressDetail,
-    progressDescription,
-    completionDate,
-    dateDescription,
-  ] = m;
-  const name = nameRaw?.trim() || "";
-  const note = progressDescription || dateDescription || "";
-
-  return {
-    bgmId: subjectId || undefined,
-    title: name,
-    rawTitle: nameRaw || "",
-    marks: episodeProgress || undefined,
-    progressDetail: progressDetail || undefined,
-    date: completionDate || undefined,
-    note: note,
-  };
-}
-
-function formatBangumiPlanDateTime(date = new Date()) {
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  return `<${year}/${month}/${day} ${hours}:${minutes}>`;
-}
-
-function applyCurrentTimeToEntryLine(line, timestamp = formatBangumiPlanDateTime()) {
-  if (!parseEntryLine(line)) return null;
-
-  const existingDateRegex = /<[\d/\-:\s]+>/;
-  if (existingDateRegex.test(line)) {
-    return line.replace(existingDateRegex, timestamp);
-  }
-
-  const insertAt = line.trimEnd().length;
-  return line.slice(0, insertAt) + timestamp + line.slice(insertAt);
-}
 
 /**
  * @param {vscode.ExtensionContext} context

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,74 @@
+/**
+ * 解析条目行的函数
+ * @param {string} line - 要解析的行
+ * @returns {object|null} - 解析结果对象或null
+ */
+function parseEntryLine(line) {
+  const indentLength = 8;
+
+  // 与 tmLanguage.json 一致的正则
+  const entryRegex = new RegExp(
+    `^\\s{${indentLength}}(?:\\[(\\d+)\\])?(.+?)(?:\\s*(?:([√☑✅✓✔🗸]+)|\\[正在观看\\s+([^\\]]+)\\])(?:\\s*\\(([^)]+)\\))?)?(?:\\s*<([\\d/\\-:\\s]+)>(?:\\s*\\(([^)]+)\\))?)?\\s*$`
+  );
+  const m = line.match(entryRegex);
+  if (!m) return null;
+
+  // 捕获组对应：
+  // 1: subject_id (bgmId)
+  // 2: 名称 (name)
+  // 3: 进度标记 (episode_progress)
+  // 4: 进度详情 (progress_detail)
+  // 5: 进度说明 (progress_description)
+  // 6: 完成时间 (completion_date)
+  // 7: 日期说明 (date_description)
+  const [
+    ,
+    subjectId,
+    nameRaw,
+    episodeProgress,
+    progressDetail,
+    progressDescription,
+    completionDate,
+    dateDescription,
+  ] = m;
+  const name = nameRaw?.trim() || "";
+  const note = progressDescription || dateDescription || "";
+
+  return {
+    bgmId: subjectId || undefined,
+    title: name,
+    rawTitle: nameRaw || "",
+    marks: episodeProgress || undefined,
+    progressDetail: progressDetail || undefined,
+    date: completionDate || undefined,
+    note: note,
+  };
+}
+
+function formatBangumiPlanDateTime(date = new Date()) {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `<${year}/${month}/${day} ${hours}:${minutes}>`;
+}
+
+function applyCurrentTimeToEntryLine(line, timestamp = formatBangumiPlanDateTime()) {
+  if (!parseEntryLine(line)) return null;
+
+  const existingDateRegex = /<[\d/\-:\s]+>/;
+  if (existingDateRegex.test(line)) {
+    return line.replace(existingDateRegex, timestamp);
+  }
+
+  const insertAt = line.trimEnd().length;
+  return line.slice(0, insertAt) + timestamp + line.slice(insertAt);
+}
+
+module.exports = {
+  parseEntryLine,
+  formatBangumiPlanDateTime,
+  applyCurrentTimeToEntryLine,
+};

--- a/test/entryRegex.test.js
+++ b/test/entryRegex.test.js
@@ -4,7 +4,7 @@ const {
   parseEntryLine,
   formatBangumiPlanDateTime,
   applyCurrentTimeToEntryLine,
-} = require("../extension.js");
+} = require("../parser.js");
 
 // 使用 Mocha 的 describe/it 结构执行测试用例
 describe("parseEntryLine", () => {


### PR DESCRIPTION
## 变更

- 新增 `parser.js`，承接条目解析、当前时间格式化和条目时间更新逻辑。
- `extension.js` 改为引用纯 parser 模块，继续只负责 VS Code provider 和 code action。
- 解析测试改为直接引用 `parser.js`，不再依赖 `vscode` 模块。

## 影响

解析相关测试可以脱离 VS Code 扩展宿主直接运行，反馈更快，也降低扩展入口文件的职责密度。

## 验证

- 直接运行 Mocha 解析测试：35 passing。
- 使用 VS Code 测试入口运行扩展测试：35 passing。
